### PR TITLE
Fix: cache不更新当修改sharpOptions压缩参数

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,6 @@ const generateFileByCache = (imgInfo: ImgInfo) => {
  */
 const generateCacheFileName = (imgInfo: ImgInfo, compressOption: SharpOption) => {
 	const { newFileName, newExt } = imgInfo
-	console.log('Hash:',`${newFileName}${JSON.stringify(compressOption)}`);
 	
 	const cacheName = createHash('sha256')
 		.update(`${newFileName}${JSON.stringify(compressOption)}`)


### PR DESCRIPTION
问题：当启用cache并成功打包过一次后，修改了压缩参数sharpOptions，
重新打包会误用之前的缓存文件，导致文件不更新成新参数下的压缩结果。

解决方法：调用diskCache.set和diskCache.get前，对新文件名和压缩参数进行Hash。