### PR TITLE
fix: 修复Windows路径问题和public目录下图片处理

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -318,8 +318,9 @@ const changeBundleOutput = (imgInfo: ImgInfo, imgBuffer: Buffer, bundler: Output
  */
 const changePublicOutput = (imgInfo: ImgInfo, imgBuffer: Buffer) => {
 	const publicDirFull = path.resolve(publicDir)
-	const oldFilePath = path.join(outputDir, path.relative(publicDirFull, imgInfo.oldFileName))
-	const newFilePath = path.join(outputDir, path.relative(publicDirFull, imgInfo.newFileName))
+	const isFileNameAbs = path.isAbsolute(imgInfo.oldFileName)
+	const oldFilePath = path.join(outputDir, isFileNameAbs ? path.relative(publicDirFull, imgInfo.oldFileName) : imgInfo.oldFileName)
+	const newFilePath = path.join(outputDir, isFileNameAbs ? path.relative(publicDirFull, imgInfo.newFileName) : imgInfo.newFileName)
 	if (recordsMap.has(imgInfo.oldFileName) && (
 		recordsMap.get(imgInfo.oldFileName).isCache ||
 		recordsMap.get(imgInfo.oldFileName).newSize < recordsMap.get(imgInfo.oldFileName).oldSize


### PR DESCRIPTION
1. 修复glob.glob在Windows平台的路径兼容性问题
   - 修复在 Windows 下类似 [vite-plugin-minipic] ENOENT: no such file or directory, mkdir 'D:\Documents\My Projects\home-page\dist\D:\Documents\My Projects\home-page\public' 的错误
   - 统一处理为相对路径，解决Windows下报错问题

2. 优化public目录图片处理策略
   - 不再对public目录下的图片进行格式转换(如png->webp)
   - 仅在原格式内进行压缩(如png->png)，避免引用路径与实际文件不匹配

已在 Windows 和 Linux 平台测试。